### PR TITLE
Basic lobbies implementation.

### DIFF
--- a/app/models/lobby.rb
+++ b/app/models/lobby.rb
@@ -1,0 +1,23 @@
+class Lobby < ActiveRecord::Base
+  belongs_to :host, :class_name => 'User'
+
+  serialize :playlists_by_user_id
+
+  after_initialize :default_values
+
+  def users
+    playlists_by_user_id.keys.map do |user_id|
+      User.find(user_id)
+    end
+  end
+
+  def playlists
+    playlists_by_user_id.values
+  end
+
+  private
+
+  def default_values
+    self.playlists_by_user_id ||= {}
+  end
+end

--- a/db/migrate/20160430125549_create_lobbies.rb
+++ b/db/migrate/20160430125549_create_lobbies.rb
@@ -1,0 +1,12 @@
+class CreateLobbies < ActiveRecord::Migration
+  def change
+    create_table :lobbies do |t|
+      t.string :name
+      t.belongs_to :host
+      t.string :playlist_id
+
+      # Store as a hash.
+      t.text :playlists_by_user_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160429141113) do
+ActiveRecord::Schema.define(version: 20160430125549) do
+
+  create_table "lobbies", force: true do |t|
+    t.string  "name"
+    t.integer "host_id"
+    t.string  "playlist_id"
+    t.text    "playlists_by_user_id"
+  end
 
   create_table "users", force: true do |t|
     t.string   "email",               default: "", null: false

--- a/spec/models/lobby_spec.rb
+++ b/spec/models/lobby_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Lobby, :type => :model do
+  let(:user) {
+    User.create(:email => 'test@gmail.com', :password => 'ohnoapassword')
+  }
+  let(:playlist_id) { '235lzkkl3j5sd' }
+
+  context 'for uninitialized lobby' do
+    let(:lobby) { Lobby.create }
+
+    it 'returns uninitialized fields' do
+      l = Lobby.find(lobby.id)
+      l.users.should == []
+      l.playlists.should == []
+    end
+  end
+
+  context 'for initialized lobby' do
+    let(:lobby) {
+      l = Lobby.new
+      l.playlists_by_user_id = { user.id => playlist_id }
+      l.save
+      l
+    }
+
+    it 'returns initialized fields' do
+      l = Lobby.find(lobby.id)
+
+      l.users.should include(user)
+      l.playlists.should include(playlist_id)
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/DarryQueen/Round-Robin/issues/5.

In retrospect, this is a fairly poor implementation. Without adding a relationship between lobbies and [joined] users, there is no way for users to see the lobbies they are currently in. However, a many-to-many feels like a layer of unnecessary complexity because users' IDs are already stored in the `playlists_by_user_id` hash. Ultimately, we have to store the playlists by user in some hash or table form because playlists are unique to a user.

@dianecw
